### PR TITLE
prometheus

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 FROM klakegg/hugo:0.71.1-onbuild AS hugo
 
-FROM nginx:1.17.10-alpine
+FROM nginx:1.19.1-alpine
 COPY --from=hugo /target /usr/share/nginx/html
+# OVerwrite to get stub status metrics
+COPY default.conf /etc/nginx/conf.d/default.conf

--- a/default.conf
+++ b/default.conf
@@ -1,0 +1,50 @@
+server {
+    listen       80;
+    listen  [::]:80;
+    server_name  localhost;
+
+    #charset koi8-r;
+    #access_log  /var/log/nginx/host.access.log  main;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+    }
+
+    location /metrics {
+        stub_status on;
+    }
+
+    #error_page  404              /404.html;
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+
+    # proxy the PHP scripts to Apache listening on 127.0.0.1:80
+    #
+    #location ~ \.php$ {
+    #    proxy_pass   http://127.0.0.1;
+    #}
+
+    # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
+    #
+    #location ~ \.php$ {
+    #    root           html;
+    #    fastcgi_pass   127.0.0.1:9000;
+    #    fastcgi_index  index.php;
+    #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
+    #    include        fastcgi_params;
+    #}
+
+    # deny access to .htaccess files, if Apache's document root
+    # concurs with nginx's one
+    #
+    #location ~ /\.ht {
+    #    deny  all;
+    #}
+}
+

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,16 +6,5 @@ services:
       context: .
       args:
         - HUGO_ENV_ARG=production
-    networks:
-      - drop
-    labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.cvsite.rule=Host(`${HOST}`)"
-      - "traefik.http.routers.cvsite.entrypoints=websecure"
-      - "traefik.http.routers.cvsite.tls.certresolver=doresolver"
-      - "traefik.http.services.cvsite.loadbalancer.server.port=80"
-    restart: unless-stopped
-
-networks:
-  drop:
-    external: true
+    ports:
+      - 80:80


### PR DESCRIPTION
Expose nginx metrics

Expose nginx stub_status metrics such that it can be processed by prometheus later on.
